### PR TITLE
Pull Request: The pre-multiplied projViewMatrix in SpriteBatch.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -6,7 +6,7 @@
 	<classpathentry kind="lib" path="lib/lwjgl_util.jar"/>
 	<classpathentry kind="lib" path="lib/lwjgl.jar">
 		<attributes>
-			<attribute name="org.eclipse.jdt.launching.CLASSPATH_ATTR_LIBRARY_PATH_ENTRY" value="lwjgl-basics/native/macosx"/>
+			<attribute name="org.eclipse.jdt.launching.CLASSPATH_ATTR_LIBRARY_PATH_ENTRY" value="lwjgl-basics/native/linux"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="output" path="bin"/>

--- a/src/mdesl/test/VertexArrayExample.java
+++ b/src/mdesl/test/VertexArrayExample.java
@@ -92,7 +92,7 @@ public class VertexArrayExample {
 
 	protected void resize() {
 		glViewport(0, 0, Display.getWidth(), Display.getHeight());
-		batch.updateProjection();
+		batch.updateMatrices();
 	}
 
 	protected void create() {
@@ -135,7 +135,7 @@ public class VertexArrayExample {
 		translate.set(-rotationPointX, -rotationPointY, 0);
 		batch.getViewMatrix().translate(translate);
 		// Upload the view matrix to the GPU:
-		batch.updateView();
+		batch.updateMatrices();
 
 		// Begin rendering:
 		batch.begin();


### PR DESCRIPTION
I tried to improve the version of my last Pull Request, as you suggested:

I removed the "updateView()" method in SpriteBatch, and changed the "updateProjection()" method into "updateMatrices()".

I also added the utility method "storeUniformMat4(String uniform, Matrix4f mat, boolean transposed)" to ShaderProgram. This method stores a Matrix4f in the given uniform, either transposed or left as-is. This method also throws a "IllegalStateException" if "getUniformLocation()" returns -1.

Finally I changed the VertexArrayExample and everything worked perfectly.

Hope you take this one as an improvement, and I hope I was helpful :)
